### PR TITLE
Update node-server to route requests back to server

### DIFF
--- a/node-server/now.json
+++ b/node-server/now.json
@@ -2,5 +2,8 @@
   "version": 2,
   "builds": [
     { "src": "index.js", "use": "@now/node-server" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "index.js" }
   ]
 }


### PR DESCRIPTION
Proposing to add the routing configuration property from `nodejs-express/now.json` to `node-server/now.json`, to be more clear about how to handle all requests via the `node-server`.

This may or may not be ideal to include as a default for this example and may be better suited as a note in the documentation.

https://zeit.co/docs/v2/deployments/official-builders/node-js-server-now-node-server/

Also, not sure regarding the possibility for community contributions to the documentation.
